### PR TITLE
Improve CLI output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ All PDF files found in the current directory and its subdirectories will be merg
 ### Options
 
 - `-e, --even`  Add a blank page to PDFs that end on an odd number of pages. Useful for manual duplex printing.
+- `-o, --output <file>`  Specify the output PDF name. Defaults to `merged.pdf`.
 
 Example:
 
 ```bash
 mergepdfs --even
+mergepdfs --output combined.pdf
 ```
 
 ## Testing

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -61,3 +61,20 @@ test('adds blank pages with --even', async () => {
   const ext = new pdfjs.ExternalDocument(merged);
   assert.equal(ext.pageCount, 4);
 });
+
+test('respects --output option', async () => {
+  const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'mergepdfs-output-'));
+  const f1 = path.join(tmp, 'one.pdf');
+  const sub = path.join(tmp, 'sub');
+  await fsp.mkdir(sub);
+  const f2 = path.join(sub, 'two.pdf');
+  await createPdf(f1, 1);
+  await createPdf(f2, 1);
+
+  const outFile = path.join(tmp, 'combined.pdf');
+  await runCli(tmp, ['--output', outFile]);
+
+  const merged = fs.readFileSync(outFile);
+  const ext = new pdfjs.ExternalDocument(merged);
+  assert.equal(ext.pageCount, 2);
+});


### PR DESCRIPTION
## Summary
- add `--output` argument to let the user specify the output PDF file
- document the new option in the README
- test output file handling with a new unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68485e2a1778832c9fb31c2eb9cf52e7